### PR TITLE
Fix robot tests

### DIFF
--- a/documentation/dev/robot_testing.md
+++ b/documentation/dev/robot_testing.md
@@ -1,0 +1,27 @@
+## Robot testing in CAST
+
+Robot tests could be run as following (<ins>first, make sure you have your venv activated and you are in a project directory</ins>):
+
+```bash
+cd tests/
+pip install -r requirements.txt
+invoke test
+```
+
+### Argument files
+
+Robot tests are using argument files which are providing variables to test files and thus makes tests independent of runtime environments. It is also easier to expand tests when all variables are on their own file.
+
+Structure of the file could be something like this:
+
+```
+--variable BROWSER:chrome
+--variable HOSTNAME:127.0.0.1
+--variable PORT:3000
+--variable SETUP:local-dev.Start Django and open browser
+--variable RESOURCE:local-dev.robot
+```
+
+### Expanding tests
+
+Just add your scenarios to existing files or create new files if necessary and update new variables into [container.args](../../tests/robottest/container.args) and [local-dev.args](../../tests/robottest/local-dev.args) files.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 robotframework
 robotframework-pythonlibcore
 robotframework-seleniumlibrary
+invoke

--- a/tests/robottest/container.args
+++ b/tests/robottest/container.args
@@ -1,0 +1,5 @@
+--variable BROWSER:headlessChrome
+--variable HOSTNAME:frontend
+--variable PORT:3000
+--variable SETUP:container.Init Browser
+--variable RESOURCE:container.robot

--- a/tests/robottest/container.robot
+++ b/tests/robottest/container.robot
@@ -1,16 +1,10 @@
 *** Variables ***
 
-${HOSTNAME}             frontend
-${PORT}                 3000
 ${SERVER}               http://${HOSTNAME}:${PORT}/roboroute
-${BROWSER}              headlessChrome
-
 
 *** Settings ***
 
-Documentation   Django Robot Tests
 Library         SeleniumLibrary  timeout=10  implicit_wait=0
-Library         Process
 
 *** Keywords ***
 
@@ -22,18 +16,3 @@ Init Browser
     Create Webdriver    driver_name=Chrome    alias=google    chrome_options=${chrome_options}    executable_path=/usr/local/bin/chromedriver
     Set Window Size    1200    1000  #run on docker can't use Maximize Browser Window
 
-Start Django and open Browser
-  ${django process}=  Start process  python3  backend/manage.py  runserver
-  Set suite variable  ${django process}
-  Open Browser  ${SERVER}  ${BROWSER}
-
-Stop Django and close browser
-  Close Browser
-  #Terminate Process  ${django process}
-  
-Set Message
-  [arguments]  ${message}
-  Input Text  messge input  ${message}
-
-#Flush Database  
-   #TODO 

--- a/tests/robottest/ent_to_end.robot
+++ b/tests/robottest/ent_to_end.robot
@@ -1,10 +1,8 @@
 *** Variables ***
 
 *** Settings ***
-Resource        resource.robot
-Suite Setup     Init Browser
-Suite Teardown  Stop Django and close Browser
-#Test Teardown   Flush Database
+Resource        ${RESOURCE}
+Suite Setup     ${SETUP}
 
 *** Test Cases ***
 

--- a/tests/robottest/local-dev.args
+++ b/tests/robottest/local-dev.args
@@ -1,0 +1,5 @@
+--variable BROWSER:chrome
+--variable HOSTNAME:127.0.0.1
+--variable PORT:3000
+--variable SETUP:local-dev.Start Django and open browser
+--variable RESOURCE:local-dev.robot

--- a/tests/robottest/local-dev.robot
+++ b/tests/robottest/local-dev.robot
@@ -1,0 +1,27 @@
+*** Variables ***
+
+${SERVER}               http://${HOSTNAME}:${PORT}/roboroute
+
+*** Settings ***
+
+Documentation   Django Robot Tests
+Library         SeleniumLibrary  timeout=10  implicit_wait=0
+Library         Process
+
+*** Keywords ***
+
+Start Django and open Browser
+  ${django process}=  Start process  python3  backend/manage.py  runserver
+  Set suite variable  ${django process}
+  Open Browser  ${SERVER}  ${BROWSER}
+
+Stop Django and close browser
+  Close Browser
+  Terminate Process  ${django process}
+  
+Set Message
+  [arguments]  ${message}
+  Input Text  messge input  ${message}
+
+#Flush Database  
+   #TODO 

--- a/tests/tasks.py
+++ b/tests/tasks.py
@@ -1,0 +1,10 @@
+from invoke import task
+
+
+@task
+def test(ctx):
+    ctx.run("robot --argumentfile robottest/local-dev.args robottest")
+
+@task
+def container_test(ctx):
+    ctx.run("robot --argumentfile robottest/container.args robottest")


### PR DESCRIPTION
Add option to configure robot tests by argument files so tests are independent of runtime environment. This enables running same tests easily in local developmenting and in CI automation without hassling with different configurations for both.

[skip CI]