### PR TITLE
Remove hardcoded backend URIs

### DIFF
--- a/frontend/src/Services/authenticationService.js
+++ b/frontend/src/Services/authenticationService.js
@@ -1,9 +1,9 @@
 import axios from "axios"
 
 const SuccessCallback = ({ credentialResponse }) => {
-  //   console.log(credentialResponse.credential)
+  const baseUrl = process.env.REACT_APP_BACKEND_URL + "api/verify-google-token/"
 
-  const result = axios.get(process.env.REACT_APP_BACKEND_URL, {
+  const result = axios.get(baseUrl, {
     headers: {
       "Content-Type": "application/json",
       Authorization: JSON.stringify(credentialResponse.credential),

--- a/frontend/src/Services/consultantService.js
+++ b/frontend/src/Services/consultantService.js
@@ -1,6 +1,6 @@
 import axios from "axios"
 
-const baseUrl = "http://127.0.0.1:8000/api/consultant/"
+const baseUrl = process.env.REACT_APP_BACKEND_URL + "api/consultant/"
 
 const getAllConsultants = () => {
   const request = axios.get(baseUrl)


### PR DESCRIPTION
Change hardocded backend urls to use .env values instead, so configuring them is more simple and straightforward and the code obeys best practices better