### PR TITLE
Restapi filter expansion

### DIFF
--- a/backend/restapi/models.py
+++ b/backend/restapi/models.py
@@ -23,8 +23,7 @@ class Techs(models.Model):
     '''
     employee = models.ManyToManyField(Employees, through='Employee_tech_skills')
     tech_name = models.TextField(unique=True)
-    def __str__(self):
-        return self.tech_name
+
 
 class Certificate(models.Model):
     employee = models.ManyToManyField(Employees, through='Employee_certificates')
@@ -39,8 +38,6 @@ class Employee_certificates(models.Model):
     cert = models.ForeignKey(Certificate, related_name='cert_id', on_delete=models.CASCADE)
     valid_until = models.DateField(null=True)
 
-    def __str__(self):
-        return f"{self.cert} {self.valid_until}" 
 
 class Employee_tech_skills(models.Model):
     class Skill(models.IntegerChoices):
@@ -54,10 +51,7 @@ class Employee_tech_skills(models.Model):
     employee = models.ForeignKey(Employees, related_name='skills', on_delete=models.CASCADE)
     tech = models.ForeignKey(Techs, related_name='tech', on_delete=models.CASCADE)
     skill_level = models.IntegerField(choices=Skill.choices)
-    tech_preference = models.BooleanField(null=True)
-
-    def __str__(self):
-        return f"{self.tech}: {self.skill_level} {self.tech_preference}"        
+    tech_preference = models.BooleanField(null=True)      
 
 class Project(models.Model):
     employee = models.ManyToManyField(Employees, through='Employee_projects')

--- a/backend/restapi/views.py
+++ b/backend/restapi/views.py
@@ -23,10 +23,26 @@ class EmployeeFilter(rest_filters.FilterSet):
         field_name='first_name', lookup_expr='icontains')
     last_name = rest_filters.CharFilter(
         field_name='last_name', lookup_expr='icontains')
+    tech_name = rest_filters.CharFilter(method='filter_by_tech_name')
+    project = rest_filters.CharFilter(method='filter_by_project')
+    vendor = rest_filters.CharFilter(method='filter_by_vendor')
+    certificate = rest_filters.CharFilter(method='filter_by_certificate')
 
     class Meta:
-        fields = ("first_name",)
+        fields = ('first_name', 'last_name', 'tech_name', 'project', 'vendor', 'certificate')
         model = Employees
+    
+    def filter_by_tech_name(self, queryset, tech_name, value):
+        return queryset.filter(skills__tech__tech_name__icontains=value).distinct()
+    
+    def filter_by_project(self, queryset, project, value):
+        return queryset.filter(projects__project__project_name__icontains=value).distinct()
+    
+    def filter_by_vendor(self, queryset, vendor, value):
+        return queryset.filter(certificates__cert__vendor__icontains=value).distinct()
+    
+    def filter_by_certificate(self, queryset, certificate, value):
+        return queryset.filter(certificates__cert__certificate_name__icontains=value).distinct()
 
 
 class ConsultantAPIView(viewsets.ModelViewSet):


### PR DESCRIPTION
- Refactor model.py
- Create new filter-features for api/consultant. User can now filter based on
  - skills
  - certificate name
  - certificate vendor
  - project_name
All filterings are icontains. Queries can be chained, e.g. ?project=cast&tech_name=python&tech_name=haskell