### PR TITLE
Tech preference filter

### DIFF
--- a/documentation/rest_api.md
+++ b/documentation/rest_api.md
@@ -79,6 +79,8 @@ Results can be filtered with the following parameters. All string searches are c
 first_name=<str>                            # First name contains
 last_name=<str>                             # Last name contains
 tech=<str>                                  # tech skill name contains (e.g. python)
+tech_and_pref=<str>,<str>                   # tech skill and preference (true, false)*
+tech_and_level=<str>,<str>                  # tech skill and level (1,2,3)
 project=<str>                               # Project name contains
 cert_vendor=<str>                           # Certificate vendor contains
 certificate=<str>                           # Certificate name contains
@@ -96,4 +98,23 @@ Additionally the same parameter can be used multiple times
 
 ```
 api/consultant?tech=python&tech=javascript
+```
+
+**Parameters with multiple arguments**
+Arguments must be separated with a comma (",").
+
+`tech_and_pref` converts other values than lowercase "true" to `False` for the second argument given. If second parameter is missing, second parameter is considered to be `True`. Examples:
+
+```
+api/consultants/?tech_and_pref=cobol,true                     # Returns workers with Cobol as skill and preference True
+api/consultants/?tech_and_pref=python,false                   # Returns workers with Python as skill and preference False
+api/consultants/?tech_and_pref=JavaScript                     # Returns workers with JavaScript as skill and preference True
+```
+
+`tech_and_level`: the second argument is converted into an integer in range 1-3. If the given value is not an integer, the value is transformed into 1. Integers will be handled with the rule $\texttt{value}\ge\max\{0, \min\{\texttt{value}, 3\}\}$. Examples:
+
+```
+api/consultants/?tech_and_pref=cobol,2                     # Returns workers with Cobol as skill and level gte 2
+api/consultants/?tech_and_pref=python                      # Returns workers with Python as skill and level gte 1
+api/consultants/?tech_and_pref=JavaScript,500              # Returns workers with JavaScript as skill and level gte 3
 ```


### PR DESCRIPTION
New feature detailed in documentation. Tech skills can now be filtered with additional arguments: pereference or level. 

Known issue:
- Last pull request contained a bug: if api request contains filtering with multiple techs, the search result is filtered as OR-request regarding tech skills. For instance if the api-request has tech=python&tech=java, users with either skills containing string 'python' or string 'java' are included. The wanted behaviour is to include users that have both 'java' and 'python' in their skill. There is a new task open regarding a bug fix. 