### PR TITLE
Expand consultant api tests

### DIFF
--- a/backend/restapi/serializers.py
+++ b/backend/restapi/serializers.py
@@ -64,10 +64,6 @@ class ConsultantSerializer(serializers.ModelSerializer):
             This action should be refactored if time permits. 
         '''
 
-        with open ("partial_update.log", "w") as file:
-            for key, value in validated_data.items():
-                file.write(f"{key}: {value}\n")
-
         instance.first_name = validated_data.get(
             'first_name', instance.first_name)
         instance.last_name = validated_data.get(


### PR DESCRIPTION
What's new:
- Unittests for updating constultant information expanded. Tests now cover updating and adding projects and certificates. 
- Removed lines for debugging from serializer. Forgotten in a previous pull request.