### PR TITLE
Filter reducer expansion

### DIFF
--- a/frontend/src/Reducers/consultantReducer.js
+++ b/frontend/src/Reducers/consultantReducer.js
@@ -1,11 +1,16 @@
- import { createSlice } from "@reduxjs/toolkit"
+import { createSlice } from "@reduxjs/toolkit"
 import consultantService from "../Services/consultantService"
+import techService from "../Services/techService"
+import certificateService from "../Services/certificateService"
 
 const initialState = {
   allConsultants: [],
   filteredConsultants: [],
-  // selectedConsultant: [],
+  filteredSkills: [],
+  filteredCertificates: [],
   activeConsultant: [],
+  allCertificates: [],
+  allTechSkills: [],
 }
 
 const consultantSlice = createSlice({
@@ -18,6 +23,18 @@ const consultantSlice = createSlice({
         allConsultants: action.payload,
       }
     },
+    setAllCertificates(state, action) {
+      return {
+        ...state,
+        allCertificates: action.payload,
+      }
+    },
+    setAllTechSkills(state, action) {
+      return {
+        ...state,
+        allTechSkills: action.payload,
+      }
+    },
     setFilteredConsultants(state, action) {
       return {
         ...state,
@@ -26,25 +43,39 @@ const consultantSlice = createSlice({
     },
     updateFilteredConsultantsByName(state, action) {
       const searchTerm = action.payload
-      state.filteredConsultants = state.allConsultants.filter((consultant) => {
-        return (
-          consultant.first_name
+      state.filteredConsultants = state.allConsultants
+        .filter((consultant) => {
+          return consultant.first_name
             .concat(" ", consultant.last_name)
             .toLowerCase()
             .includes(searchTerm.toLowerCase())
-        )
-      })
+        })
+        .filter((user) => {
+          if (state.filteredSkills.length === 0) {
+            return true
+          } else {
+            return state.filteredSkills.every((skillName) => {
+              return user.skills.some((skill) => skill.tech_name === skillName)
+            })
+          }
+        })
+        .filter((user) => {
+          if (state.filteredCertificates.length === 0) {
+            return true
+          } else {
+            return state.filteredCertificates.every((certName) => {
+              return user.certificates.some(
+                (cert) => cert.certificate === certName
+              )
+            })
+          }
+        })
     },
-    // setSelectedConsultant(state, action) {
-    //   state.selectedConsultant = action.payload
-    // },
     setActiveConsultant(state, action) {
-      //state.activeConsultant = action.payload
       return {
         ...state,
         activeConsultant: action.payload,
       }
-        
     },
   },
 })
@@ -53,6 +84,10 @@ export const initializeConsultants = () => {
   return async (dispatch) => {
     const consultants = await consultantService.getAllConsultants()
     dispatch(setAllConsultants(consultants))
+    const certificates = await certificateService.getAllCertificates()
+    dispatch(setAllCertificates(certificates))
+    const techSkills = await techService.getAllTechs()
+    dispatch(setAllTechSkills(techSkills))
     dispatch(setFilteredConsultants(consultants))
   }
 }
@@ -63,6 +98,8 @@ export const {
   updateFilteredConsultantsByName,
   setSelectedConsultant,
   setActiveConsultant,
+  setAllCertificates,
+  setAllTechSkills,
 } = consultantSlice.actions
 
 export default consultantSlice.reducer

--- a/frontend/src/Services/certificateService.js
+++ b/frontend/src/Services/certificateService.js
@@ -1,0 +1,10 @@
+import axios from "axios"
+
+const baseUrl = process.env.REACT_APP_BACKEND_URL + "api/certificates/"
+
+const getAllCertificates = () => {
+  const request = axios.get(baseUrl)
+  return request.then((response) => response.data)
+}
+
+export default { getAllCertificates }


### PR DESCRIPTION
# Expanding reducer for filtering consultants
**Related user stories:** #12 and #13

## Purpose
In the ongoing sprint two new filter functionalities will be implemented. The consultants can be filtered based on selected technical skills and selected certificates. To lay ground work for this, the following changes have been made:

- filter reducer has been expanded and updated
- a new service was created for importing certificates
- initializing conultant information has been expanded. 
- consultant state has been expanded

## An example (attached file)
As the feature can not be tested in it's current state, a testable version of the new reducer-feature has been attached. To test this locally, download and uncompress the file and run in with command
```
node index.js
```
You can change the filter values to test the feature more in-depth.

## Known issues
Refactoring redux store should be considered. Not everything in consultantReducer should perhaps be there. 

[test-file.zip](https://github.com/Cast2023/cast/files/11090446/test-file.zip)
