### PR TITLE
Search view skill filter tests

### DIFF
--- a/robot/tests/search_view.robot
+++ b/robot/tests/search_view.robot
@@ -53,4 +53,37 @@ Scenario: As a visitor I can still see the search results after visiting another
   Click Element  search
   Page Should Not Contain  Bruce
   Page Should Contain  Gwen
-  
+
+
+Scenario: As a visitor I can filter consultants based on selected skill
+  Refresh & Navigate to Selected View  search
+  Wait Until Page Contains Element  skills-combo-box
+  Click Element  skills-combo-box
+  Click Element  id=skills-combo-box-option-0
+  Sleep  2s
+  Page Should Not Contain Element  id=7
+
+Scenario: As a visitor I can filter consultants based on multiple selected skills
+  Refresh & Navigate to Selected View  search
+  Wait Until Page Contains Element  skills-combo-box
+  Click Element  skills-combo-box
+  Click Element  id=skills-combo-box-option-0
+  Click Element  skills-combo-box
+  Click Element  id=skills-combo-box-option-1
+  Sleep  2s
+  Page Should Contain Element  id=3
+  Page Should Not Contain Element  id=4
+
+Scenario: As a visitor when I return to search view my selected skill filtering remains unchanged
+  Refresh & Navigate to Selected View  search
+  Wait Until Page Contains Element  skills-combo-box
+  Click Element  skills-combo-box
+  Click Element  id=skills-combo-box-option-0
+  Click Element  skills-combo-box
+  Click Element  id=skills-combo-box-option-1
+  Click Element  home
+  Click Element  profile
+  Click Element  search
+  Sleep  2s
+  Page Should Contain Element  id=3
+  Page Should Not Contain Element  id=7

--- a/robot/tests/search_view.robot
+++ b/robot/tests/search_view.robot
@@ -20,9 +20,11 @@ Scenario: As a visitor I can write text to search bar
 Scenario: As a visitor I can filter shown consultants
   Refresh & Navigate to Selected View  search
   Wait Until Page Contains Element  search_bar
+  Wait Until Page Contains Element  id=20
   Click element  search_bar
   Sleep  2s
   Set Value  search_bar  Gwen
+  Sleep  2s
   Page Should Not Contain  Bruce
   Page Should Contain  Gwen
 
@@ -60,16 +62,22 @@ Scenario: As a visitor I can filter consultants based on selected skill
   Wait Until Page Contains Element  skills-combo-box
   Click Element  skills-combo-box
   Sleep  1s
-  Click Element  id=skills-combo-box-option-9
+  Set Selenium Speed	2.5 seconds
+  Click Element  id=skills-combo-box-option-2
+  Set Selenium Speed	0 seconds
+  Click Element  profile
   Sleep  1s
-  Page Should Not Contain Element  id=1
+  Click Element  search
+  Wait Until Page Contains Element  id=1
+  Sleep  2s
+  Page Should Not Contain Element  id=2
 
 Scenario: As a visitor I can filter consultants based on multiple selected skills
   Refresh & Navigate to Selected View  search
   Wait Until Page Contains Element  skills-combo-box
   Click Element  skills-combo-box
   Sleep  1s
-  Click Element  id=skills-combo-box-option-0
+  Click Element  id=skills-combo-box-option-2
   Sleep  1s
   Click Element  skills-combo-box
   Sleep  1s
@@ -83,7 +91,7 @@ Scenario: As a visitor when I return to search view my selected skill filtering 
   Refresh & Navigate to Selected View  search
   Wait Until Page Contains Element  skills-combo-box
   Click Element  skills-combo-box
-  Click Element  id=skills-combo-box-option-0
+  Click Element  id=skills-combo-box-option-2
   Click Element  skills-combo-box
   Click Element  id=skills-combo-box-option-1
   Click Element  home

--- a/robot/tests/search_view.robot
+++ b/robot/tests/search_view.robot
@@ -59,19 +59,24 @@ Scenario: As a visitor I can filter consultants based on selected skill
   Refresh & Navigate to Selected View  search
   Wait Until Page Contains Element  skills-combo-box
   Click Element  skills-combo-box
-  Click Element  id=skills-combo-box-option-0
-  Sleep  2s
-  Page Should Not Contain Element  id=7
+  Sleep  1s
+  Click Element  id=skills-combo-box-option-9
+  Sleep  1s
+  Page Should Not Contain Element  id=1
 
 Scenario: As a visitor I can filter consultants based on multiple selected skills
   Refresh & Navigate to Selected View  search
   Wait Until Page Contains Element  skills-combo-box
   Click Element  skills-combo-box
+  Sleep  1s
   Click Element  id=skills-combo-box-option-0
+  Sleep  1s
   Click Element  skills-combo-box
+  Sleep  1s
   Click Element  id=skills-combo-box-option-1
-  Sleep  2s
+  Sleep  1s
   Page Should Contain Element  id=3
+  Sleep  1s
   Page Should Not Contain Element  id=4
 
 Scenario: As a visitor when I return to search view my selected skill filtering remains unchanged
@@ -83,6 +88,7 @@ Scenario: As a visitor when I return to search view my selected skill filtering 
   Click Element  id=skills-combo-box-option-1
   Click Element  home
   Click Element  profile
+  Sleep  1s
   Click Element  search
   Sleep  2s
   Page Should Contain Element  id=3


### PR DESCRIPTION
## General
Related user story: #12
Related task: #341

## Overview
Following tests have been created
- Test consultants are filtered based on one selected skill
- Test consultants are filtered based on two selected skills
- Test skill selection remains unchanged if user navigates to another view and returns then to search view. 