### PR TITLE
Add argument to invoke-command

### DIFF
--- a/robot/tasks.py
+++ b/robot/tasks.py
@@ -1,9 +1,10 @@
 from invoke import task
 
 
-@task
-def test(ctx):
-    ctx.run("robot --argumentfile variables/local-dev.args tests")
+@task(optional=['file'])
+def test(ctx, file=""):
+    ctx.run(f"robot --argumentfile variables/local-dev.args tests/{file}")
+
 
 @task
 def container_test(ctx):


### PR DESCRIPTION
Added an optional argument in `tasks.py` for command `test`

Use example:
```
invoke test --file=search_view.robot
```

All tests can be run by using the prompt `invoke test` without the optional argument. 